### PR TITLE
Adding line folding

### DIFF
--- a/encoder_test.go
+++ b/encoder_test.go
@@ -16,3 +16,57 @@ func TestEncoder(t *testing.T) {
 		t.Errorf("Encode() = \n%v\nbut want:\n%v", s, exampleCalendarStr)
 	}
 }
+
+func TestEncoder_encodeProp(t *testing.T) {
+	enc := &Encoder{
+		maxLineLength: 13,
+	}
+
+	tests := []struct {
+		name string
+		prop Prop
+		want string
+	}{
+		{name: "short", prop: Prop{Name: "FOO", Value: "BAR"}, want: "FOO:BAR"},
+		{name: "multibyte", prop: Prop{Name: "A", Value: "Ḽơᶉëᶆ ȋṕšᶙṁ"}, want: "A:Ḽơᶉë\r\n ᶆ ȋṕš\r\n ᶙṁ"},
+		{name: "exact length", prop: Prop{Name: "FOUR", Value: "+ eight!"}, want: "FOUR:+ eight!"},
+		{
+			name: "exceeding line limit",
+			prop: Prop{
+				Name:  "FOO",
+				Value: "Exceeding line limit",
+			},
+			want: "FOO:Exceeding\r\n  line limit",
+		},
+		{
+			name: "with params",
+			prop: Prop{
+				Name: "A",
+				Params: Params{
+					ParamEncoding: []string{"8bit"},
+				},
+				Value: "B",
+			},
+			want: "A;ENCODING=8b\r\n it:B",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			enc := enc
+			enc.w = &buf
+
+			err := enc.encodeProp(&tt.prop)
+			if err != nil {
+				t.Errorf("encodeProp() error = %v", err)
+			}
+
+			got := buf.String()
+			want := tt.want + "\r\n"
+			if got != want {
+				t.Errorf("expected %q, but got %q", want, got)
+			}
+		})
+	}
+}

--- a/ical_test.go
+++ b/ical_test.go
@@ -15,7 +15,8 @@ PRODID:-//xyz Corp//NONSGML PDA Calendar Version 1.0//EN
 VERSION:2.0
 BEGIN:VEVENT
 CATEGORIES:CONFERENCE
-DESCRIPTION;ALTREP="cid:part1.0001@example.org":Networld+Interop Conference and Exhibit\nAtlanta World Congress Center\n Atlanta\, Georgia
+DESCRIPTION;ALTREP="cid:part1.0001@example.org":Networld+Interop Conference
+  and Exhibit\nAtlanta World Congress Center\n Atlanta\, Georgia
 DTEND:19960920T220000Z
 DTSTAMP:19960704T120000Z
 DTSTART:19960918T143000Z


### PR DESCRIPTION
Following the [recommendation](https://tools.ietf.org/html/rfc5545#section-3.1), I've added line-folding with multi-byte character support.

Feel free to fire away review feedback :-)

Couple of notes:
- The generated ICS validates on: https://icalendar.org/validator.html
- The spec shows `N+1` indent per line, but I think the specification is somewhat ambiguous and I've found real-world examples who continue with just 1 indent per subsequent line.
- This PR introduces a dependency on at least Go 1.10