### PR TITLE
Add helper to parse RRULE prop

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -36,6 +36,7 @@ func checkComponent(comp *Component) error {
 			PropLocation,
 			PropOrganizer,
 			PropPriority,
+			PropRecurrenceRule,
 			PropSequence,
 			PropStatus,
 			PropSummary,

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/emersion/go-ical
 
 go 1.13
+
+require github.com/teambition/rrule-go v1.7.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/teambition/rrule-go v1.7.2 h1:goEajFWYydfCgavn2m/3w5U+1b3PGqPUHx/fFSVfTy0=
+github.com/teambition/rrule-go v1.7.2/go.mod h1:mBJ1Ht5uboJ6jexKdNUJg2NcwP8uUMNvStWXlJD3MvU=


### PR DESCRIPTION
This relies on [rrule-go][1], which implements RRULEs logic itself. The
helper merely returns an `ROption` object.

See the inline documentation for Props.ROption for finer details.

[1]: https://github.com/teambition/rrule-go