### PR TITLE
Add setter for DATE value type

### DIFF
--- a/ical.go
+++ b/ical.go
@@ -155,6 +155,11 @@ func (prop *Prop) DateTime(loc *time.Location) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("ical: cannot process: (%q) %s", valueType, prop.Value)
 }
 
+func (prop *Prop) SetDate(t time.Time) {
+	prop.SetValueType(ValueDate)
+	prop.Value = t.Format("20060102")
+}
+
 func (prop *Prop) SetDateTime(t time.Time) {
 	prop.SetValueType(ValueDateTime)
 	switch t.Location() {
@@ -427,6 +432,12 @@ func (props Props) DateTime(name string, loc *time.Location) (time.Time, error) 
 		return prop.DateTime(loc)
 	}
 	return time.Time{}, nil
+}
+
+func (props Props) SetDate(name string, t time.Time) {
+	prop := NewProp(name)
+	prop.SetDate(t)
+	props.Set(prop)
 }
 
 func (props Props) SetDateTime(name string, t time.Time) {

--- a/ical_test.go
+++ b/ical_test.go
@@ -260,6 +260,48 @@ func TestSetDate(t *testing.T) {
 	testCases := []struct {
 		Alias        string
 		Date         time.Time
+		ExpectedDate string
+	}{
+		{
+			Alias:        "UTC",
+			Date:         time.Date(2020, time.September, 20, 0, 0, 0, 0, time.UTC),
+			ExpectedDate: "20200920",
+		},
+		{
+			Alias:        "local",
+			Date:         time.Date(2020, time.September, 20, 0, 0, 0, 0, localTimezone),
+			ExpectedDate: "20200920",
+		},
+		{
+			Alias:        "non_zero_time",
+			Date:         time.Date(2020, time.September, 20, 17, 7, 0, 0, localTimezone),
+			ExpectedDate: "20200920",
+		},
+	}
+
+	for _, tCase := range testCases {
+		t.Run(tCase.Alias, func(t *testing.T) {
+			p := NewProp("FakeProp")
+			p.SetDate(tCase.Date)
+			if got, want := p.Value, tCase.ExpectedDate; got != want {
+				t.Errorf("bad date: %s, expected: %s", got, want)
+			}
+			if got, want := p.Params.Get(PropTimezoneID), ""; got != want {
+				t.Errorf("bad tzid: %s, expected: %s", got, want)
+			}
+		})
+	}
+}
+
+func TestSetDateTime(t *testing.T) {
+	localTimezone, err := time.LoadLocation("Europe/Paris")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		Alias        string
+		Date         time.Time
 		ExpectedTZID string
 		ExpectedDate string
 	}{


### PR DESCRIPTION
Add a setter for the `DATE` value type. Do not set the `TZID` property parameter, as the RFC specifies.