### PR TITLE
Do not apply TZID to DATE properties

### DIFF
--- a/ical_test.go
+++ b/ical_test.go
@@ -212,7 +212,7 @@ func TestGetDate(t *testing.T) {
 			ValueType:    ValueDate,
 			TZID:         "Europe/Paris",
 			Location:     nil,
-			ExpectedDate: time.Date(2020, time.September, 23, 0, 0, 0, 0, localTimezone),
+			ExpectedDate: time.Date(2020, time.September, 23, 0, 0, 0, 0, time.UTC),
 		},
 		{
 			Alias:        "date-nil-local",


### PR DESCRIPTION
Based on section 3.2.19 of RFC 5545.