### PR TITLE
decoder: handle long lines

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -2,7 +2,6 @@ package ical
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"io"
 	"strings"
@@ -138,12 +137,23 @@ func NewDecoder(r io.Reader) *Decoder {
 }
 
 func (dec *Decoder) readLine() ([]byte, error) {
-	b, err := dec.br.ReadSlice('\n')
-	b = bytes.TrimRight(b, "\r\n")
-	if err == io.EOF && len(b) > 0 {
-		err = nil
+	var buf []byte
+	for {
+		line, isPrefix, err := dec.br.ReadLine()
+		if err != nil {
+			return nil, err
+		}
+
+		if !isPrefix && len(buf) == 0 {
+			return line, err
+		}
+
+		buf = append(buf, line...)
+		if !isPrefix {
+			break
+		}
 	}
-	return b, err
+	return buf, nil
 }
 
 func (dec *Decoder) readContinuedLine() (string, error) {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1,6 +1,7 @@
 package ical
 
 import (
+	"fmt"
 	"io"
 	"reflect"
 	"strings"
@@ -20,5 +21,73 @@ func TestDecoder(t *testing.T) {
 
 	if _, err := dec.Decode(); err != io.EOF {
 		t.Errorf("DecodeCalendar() = %v, want io.EOF", err)
+	}
+}
+
+func TestDecoderLongLine(t *testing.T) {
+	template := `BEGIN:VCALENDAR
+PRODID:-//xyz Corp//NONSGML PDA Calendar Version 1.0//EN
+VERSION:2.0
+BEGIN:VEVENT
+DESCRIPTION:%v
+DTSTAMP:19960704T120000Z
+DTSTART:19960918T143000Z
+UID:uid1@example.com
+END:VEVENT
+END:VCALENDAR
+`
+	description := strings.Repeat("Networld+Interop Conference", 500)
+	calendarStr := toCRLF(fmt.Sprintf(template, description))
+	calendar := &Calendar{&Component{
+		Name: "VCALENDAR",
+		Props: Props{
+			"PRODID": []Prop{{
+				Name:   "PRODID",
+				Params: Params{},
+				Value:  "-//xyz Corp//NONSGML PDA Calendar Version 1.0//EN",
+			}},
+			"VERSION": []Prop{{
+				Name:   "VERSION",
+				Params: Params{},
+				Value:  "2.0",
+			}},
+		},
+		Children: []*Component{
+			{
+				Name: "VEVENT",
+				Props: Props{
+					"DTSTAMP": []Prop{{
+						Name:   "DTSTAMP",
+						Params: Params{},
+						Value:  "19960704T120000Z",
+					}},
+					"UID": []Prop{{
+						Name:   "UID",
+						Params: Params{},
+						Value:  "uid1@example.com",
+					}},
+					"DTSTART": []Prop{{
+						Name:   "DTSTART",
+						Params: Params{},
+						Value:  "19960918T143000Z",
+					}},
+					"DESCRIPTION": []Prop{{
+						Name:   "DESCRIPTION",
+						Params: Params{},
+						Value:  description,
+					}},
+				},
+			},
+		},
+	}}
+
+	dec := NewDecoder(strings.NewReader(calendarStr))
+
+	cal, err := dec.Decode()
+	if err != nil {
+		t.Fatalf("DecodeCalendar() = %v", err)
+	}
+	if !reflect.DeepEqual(cal, calendar) {
+		t.Errorf("DecodeCalendar() = \n%#v\nbut want:\n%#v", cal, calendar)
 	}
 }


### PR DESCRIPTION
In the case of a long input line, decoding fails with `bufio.ErrBufferFull`.
For example, this occurs when the event description is long enough so that the length of the line exceeds the default buffer size.
